### PR TITLE
タイプミスの修正

### DIFF
--- a/thrift_sample.thrift
+++ b/thrift_sample.thrift
@@ -1,6 +1,6 @@
 namespace go goSample
 
-enum MassageType {
+enum MessageType {
 	NORMAL = 1;
 	IMAGE = 2;
 	VIDEO = 3;
@@ -8,7 +8,7 @@ enum MassageType {
 
 struct Message {
 	1: i32 id;
-	2: MassageType type,
+	2: MessageType type,
 	3: string Content,
 }
 


### PR DESCRIPTION
Messageの綴りがThriftファイル内で誤っていたので修正しました。
`thrift --gen` して正しく動くか確認をお願いします。